### PR TITLE
API - Créer un tournoi

### DIFF
--- a/back/src/controllers/tournoi.controllers.ts
+++ b/back/src/controllers/tournoi.controllers.ts
@@ -1,6 +1,7 @@
 import { NextFunction, Request, Response } from "express";
 import { TournoiService } from "../services/tournoi.services";
 import {
+  creationTournoiSchema,
   tournoiIdSchema,
   tournoiUpdateSchema,
 } from "../lib/schemas/tournoiSchema";
@@ -49,6 +50,26 @@ export class TournoiController {
       const tournoiId = tournoiIdSchema.parse(req.params.id);
       const tournoi = await this.tournoiService.findById(tournoiId);
       res.status(200).json({ success: true, data: tournoi });
+    } catch (error: any) {
+      next(error);
+    }
+  };
+
+  /**
+   * Créer un nouveau tournoi.
+   * @param req - La requête HTTP.
+   * @param res - La réponse HTTP.
+   * @param next - La fonction middleware suivante.
+   */
+  public createTournoi = async (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    try {
+      const tournoiBody = creationTournoiSchema.parse(req.body);
+      const newTournoi = await this.tournoiService.create(tournoiBody);
+      res.status(201).json({ success: true, data: newTournoi });
     } catch (error: any) {
       next(error);
     }

--- a/back/src/lib/schemas/tournoiSchema.ts
+++ b/back/src/lib/schemas/tournoiSchema.ts
@@ -23,3 +23,17 @@ export const tournoiUpdateSchema = z.object({
     .optional(),
   estTermine: z.boolean().optional(),
 });
+
+export const creationTournoiSchema = z.object({
+  nom: z
+    .string("Le nom du tournoi doit être une chaîne de caractères")
+    .min(3, "Le nom doit contenir au moins 3 caractères")
+    .max(100, "Le nom doit contenir au maximum 100 caractères"),
+  date: z.string().refine((date) => !isNaN(Date.parse(date)), {
+    message: "Date du tournoi invalide",
+  }),
+  description: z
+    .string("La description doit être une chaîne de caractères")
+    .max(500, "La description doit contenir au maximum 500 caractères")
+    .optional(),
+});

--- a/back/src/routes/tournoi.routes.ts
+++ b/back/src/routes/tournoi.routes.ts
@@ -8,6 +8,7 @@ const tournoiController = new TournoiController();
 
 tournoiRouter.get("/", tournoiController.getTournois);
 tournoiRouter.get("/:id", tournoiController.getTournoiById);
+tournoiRouter.post("/", tournoiController.createTournoi);
 tournoiRouter.patch("/:id", tournoiController.updateTournoiById);
 tournoiRouter.delete("/:id", tournoiController.deleteTournoiById);
 tournoiRouter.post("/:id/equipes", tournoiController.createEquipesTournoi);

--- a/back/tests/tournois/createTournoi.test.ts
+++ b/back/tests/tournois/createTournoi.test.ts
@@ -1,0 +1,69 @@
+import { app } from "../../src/app";
+import { prisma } from "../../src/prisma/client";
+import request from "supertest";
+
+describe("POST /api/tournois", () => {
+  let tournoiId: string;
+
+  beforeEach(async () => {
+    // Créer un tournoi
+    const tournoi = await prisma.tournoi.create({
+      data: {
+        nom: "Tournoi ",
+        date: new Date(),
+        description: "Description du tournoi à supprimer",
+        estTermine: false,
+      },
+    });
+
+    tournoiId = tournoi.id;
+  });
+
+  afterEach(async () => {
+    await prisma.tournoi.deleteMany();
+  });
+
+  describe("Cas de succès", () => {
+    it("devrait créer un tournoi existant", async () => {
+      const response = await request(app)
+        .post(`/api/tournois`)
+        .send({
+          nom: "Tournoi 1",
+          date: new Date(),
+          description: "Description du tournoi 1",
+        })
+        .expect(201);
+
+      expect(response.body.success).toBe(true);
+    });
+  });
+  describe("Cas d'échec", () => {
+    it("devrait retourner une erreur si le nom du tournoi est manquant", async () => {
+      const response = await request(app)
+        .post(`/api/tournois`)
+        .send({
+          date: new Date(),
+          description: "Description du tournoi 1",
+        })
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.message).toBe("Le nom du tournoi est requis");
+    });
+
+    it("devrait retourner une erreur si la date du tournoi est manquante", async () => {
+      const response = await request(app)
+        .post(`/api/tournois`)
+        .send({
+          nom: "Tournoi 1",
+          description: "Description du tournoi 1",
+        })
+        .expect(400);
+
+      expect(response.body.success).toBe(false);
+      expect(response.body.error.message).toBe(
+        "La date du tournoi est requise"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Objet :memo: 
Exposer une API permettant aux administrateurs de créer des tournois.
Cette première itération est uniquement côté API (aucune UI).

- [ ] Route (POST) : /api/tournois
- [ ] Méthode controller : createTournoi
- [ ] Méthode service : createTournoi(tournoiBody)
- [x] Tests fonctionnels